### PR TITLE
Migrate server to contagion

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -91,6 +91,12 @@ jobs:
         with:
           packages: "kcov"
 
+      - name: install cargo kcov
+        uses: actions-rs/cargo@v1
+        with:
+          command: install
+          args: cargo-kcov
+
       - uses: actions-rs/cargo@v1
         name: cargo kcov
         with:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ license = "AGPL-3"
 drop = { git = "https://github.com/Distributed-EPFL/drop.git" }
 murmur = { git = "https://github.com/Distributed-EPFL/murmur.git" }
 sieve = { git = "https://github.com/Distributed-EPFL/sieve.git" }
+contagion = { git = "https://github.com/Distributed-EPFL/contagion.git" }
 bincode = "1.3.3"
 futures = "0.3"
 num_cpus = "1.13"

--- a/src/bin/server/rpc.rs
+++ b/src/bin/server/rpc.rs
@@ -1,6 +1,7 @@
 use std::convert::From;
 use std::net::SocketAddr;
 
+use contagion::{Contagion, ContagionConfig, ContagionMessage};
 use drop::crypto::key::exchange::{self, Exchanger};
 use drop::net::{ConnectorExt, TcpConnector, TcpListener};
 use drop::system::{AllSampler, Handle, NetworkSender, System, SystemManager};
@@ -8,7 +9,6 @@ use futures::future;
 use futures::StreamExt;
 use murmur::MurmurConfig;
 use sieve::SieveConfig;
-use contagion::{Contagion,ContagionConfig, ContagionMessage};
 
 use super::accounts::{self, Accounts};
 use super::config;
@@ -74,7 +74,7 @@ impl Service {
 
         let manager = SystemManager::new(system);
 
-        let sieve = Contagion::new(
+        let contagion = Contagion::new(
             contagion::Fixed::new_local(),
             ContagionConfig {
                 sieve: SieveConfig {
@@ -86,12 +86,12 @@ impl Service {
                     },
                 },
                 contagion_sample_size: network.len(),
-                ready_threshold: network.len()
+                ready_threshold: network.len(),
             },
         );
 
         let sampler = AllSampler::default();
-        let mut handle = manager.run(sieve, sampler, num_cpus::get()).await;
+        let mut handle = manager.run(contagion, sampler, num_cpus::get()).await;
 
         let handle_errors = handle.errors();
         tokio::spawn(async move {

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -268,7 +268,7 @@ async fn can_send_asset() {
         .expect("send asset");
 
     // TODO confirm transaction
-    tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+    tokio::time::sleep(std::time::Duration::from_secs(3)).await;
 
     assert_eq!(
         get_balance(first_client_config) + 10,


### PR DESCRIPTION
This migrates server to contagion instead of sieve now that contagion is production-ready