### PR TITLE
server/config: allow hostnames

### DIFF
--- a/src/bin/server/config.rs
+++ b/src/bin/server/config.rs
@@ -1,12 +1,12 @@
-use std::{io, net::SocketAddr};
+use std::io;
 
 use drop::crypto::{key::exchange, sign};
 use snafu::{ResultExt, Snafu};
 
 #[derive(serde::Deserialize, serde::Serialize)]
 pub struct ConfigAddresses {
-    pub node: SocketAddr,
-    pub rpc: SocketAddr,
+    pub node: String,
+    pub rpc: String,
 }
 
 #[derive(serde::Deserialize, serde::Serialize)]
@@ -27,7 +27,7 @@ pub struct Config {
 
 #[derive(serde::Deserialize, serde::Serialize, Debug)]
 pub struct Node {
-    pub address: SocketAddr,
+    pub address: String,
     #[serde(with = "hex")]
     pub public_key: exchange::PublicKey,
 }

--- a/tests/lib.sh
+++ b/tests/lib.sh
@@ -40,6 +40,15 @@ fail() {
 	exit 1
 }
 
+wait_for_port_connect() {
+	local port=$1
+
+	while ! nc -w 0 localhost $port
+	do
+		sleep $tick
+	done
+}
+
 readonly port_base=$((RANDOM + 1024))
 readonly port_top=$((port_base + 2*node_count - 1))
 nodes=''
@@ -70,10 +79,7 @@ start_network() {
 
 	for port in $(seq $port_base $port_top)
 	do
-		while ! nc -w 0 localhost $port
-		do
-			sleep 0.1
-		done
+		wait_for_port_connect $port
 	done
 }
 

--- a/tests/server-config-resolve-addrs
+++ b/tests/server-config-resolve-addrs
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+source ./lib.sh
+
+server config new localhost:1024 localhost:1025 |
+	server run &
+
+wait_for_port_connect 1024
+wait_for_port_connect 1025
+
+kill $!
+
+wait


### PR DESCRIPTION
only IP addresses were allowed before. does help with docker-compose as we can reference services via hostname and not via fixed (and potentially changing) IPs