### PR TITLE
Retry transactions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,9 +2,8 @@
 name = "at2-node"
 version = "0.1.0"
 authors = ["Ogier Bouvier <ogier@bouvier.family>", "Valérian Rousset <tharvik@users.noreply.github.com>"]
-edition = "2018"
+edition = "2021"
 license = "AGPL-3.0-only"
-resolver = "2"
 
 [dependencies]
 drop = { git = "https://github.com/Distributed-EPFL/drop" }

--- a/src/bin/server/accounts/account.rs
+++ b/src/bin/server/accounts/account.rs
@@ -14,7 +14,7 @@ pub struct Account {
     balance: u64,
 }
 
-const INITIAL_BALANCE: u64 = 10;
+const INITIAL_BALANCE: u64 = 100000;
 
 impl Account {
     /// Create a new account

--- a/src/bin/server/accounts/mod.rs
+++ b/src/bin/server/accounts/mod.rs
@@ -173,7 +173,7 @@ impl AccountsHandler {
         let initial_account = Account::new();
 
         if sender.eq(&receiver) {
-            warn!(?sender, "transfer to themself");
+            warn!(?sender, "transfer to itself");
 
             let account = self.ledger.get(&sender).unwrap_or(&initial_account);
 
@@ -241,7 +241,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn transfer_to_themself_increment_sequence_and_keep_balance() {
+    async fn transfer_to_themselves_increment_sequence_and_keep_balance() {
         let accounts = Accounts::new();
         let user_pubkey = Box::new(sign::KeyPair::random().public());
 
@@ -257,7 +257,7 @@ mod tests {
         accounts
             .transfer(user_pubkey.clone(), 1, user_pubkey.clone(), 10)
             .await
-            .expect("to transfer to themself");
+            .expect("to transfer to themselves");
 
         let final_balance = accounts
             .get_balance(user_pubkey.clone())

--- a/src/bin/server/accounts/mod.rs
+++ b/src/bin/server/accounts/mod.rs
@@ -5,7 +5,7 @@ use snafu::ResultExt;
 use tokio::sync::{mpsc, oneshot};
 use tracing::{debug, info, warn};
 
-mod account;
+pub mod account;
 use account::Account;
 
 #[derive(snafu::Snafu, Debug)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,7 @@ pub mod proto;
 
 /// Type of message sent via sieve
 #[drop::message]
+#[derive(PartialEq, Eq, PartialOrd, Ord)]
 pub struct ThinTransaction {
     /// User receiving the amount
     pub recipient: sign::PublicKey,


### PR DESCRIPTION
As the sieve payloads can be delivered out of order, txs can fails to process and still be valid. So, we can retry transactions failing because of out-of-order processing.
The fix here is a dirty one, in terms of complexity, but improving it would mean to have a graph representation and solving it, which is a bit overkill for a demo.

Also
* bump Rust edition
* fix grammar (thanks @ineiti)
* greatly increase initial balance