### PR TITLE
server: less failures

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,14 +8,14 @@ license = "AGPL-3.0-only"
 [dependencies]
 drop = { git = "https://github.com/Distributed-EPFL/drop" }
 sieve = { git = "https://github.com/Distributed-EPFL/sieve" }
-bincode = "1.3.3"
+bincode = "1"
 chrono = { version = "0.4", features = ["serde"] }
 http = "0.2"
 prost = { version = "0.9", default-features = false }
 serde = { version = "1", features = ["derive"] }
 snafu = "0.6"
-tonic = { version = "0.6", default-features = false, features = ["codegen", "prost"] }
 tokio = { version = "1", features = ["macros", "sync", "time"] }
+tonic = { version = "0.6", default-features = false, features = ["codegen", "prost"] }
 
 # cli
 hex = { version = "0.4", features = ["serde"], optional = true }
@@ -24,16 +24,16 @@ toml = { version = "0.5", optional = true }
 
 # client
 serde_str = { version = "0.1", optional = true }
-url = { version = "2.2", optional = true }
+url = { version = "2", optional = true }
 
 # server
 contagion = { git = "https://github.com/Distributed-EPFL/contagion", optional = true }
-futures = { version = "0.3", optional = true }
 murmur = { git = "https://github.com/Distributed-EPFL/murmur", optional = true }
-num_cpus = { version = "1.13", optional = true }
+futures = { version = "0.3", optional = true }
+num_cpus = { version = "1", optional = true }
 tonic-web = { version = "0.2", optional = true }
-tracing = { version = "0.1", optional = true }
 tracing-fmt = { version = "0.1", optional = true }
+tracing = { version = "0.1", optional = true }
 
 [target.'cfg(not(target_family = "wasm"))'.dependencies]
 tonic = { version = "0.6", default-features = false, features = ["transport"] }

--- a/src/bin/server/accounts/account.rs
+++ b/src/bin/server/accounts/account.rs
@@ -7,8 +7,8 @@ pub enum Error {
     Underflow,
 }
 
-/// Contains the balance for a user
-#[derive(Debug)]
+/// Contains the balance and the latest processed sequence for a user
+#[derive(Debug, Clone, Copy)]
 pub struct Account {
     last_sequence: sieve::Sequence,
     balance: u64,
@@ -26,21 +26,20 @@ impl Account {
     }
 
     /// Add some amount to this account
-    pub fn credit(&self, amount: u64) -> Result<Self, Error> {
-        Ok(Self {
-            last_sequence: self.last_sequence,
-            balance: self.balance.checked_add(amount).context(Overflow)?,
-        })
+    pub fn credit(&mut self, amount: u64) -> Result<(), Error> {
+        self.balance = self.balance.checked_add(amount).context(Overflow)?;
+
+        Ok(())
     }
 
     /// Remove some amount from this account, iff the `sequence` is consecutive to the last one
-    pub fn debit(&self, sequence: sieve::Sequence, amount: u64) -> Result<Self, Error> {
+    pub fn debit(&mut self, sequence: sieve::Sequence, amount: u64) -> Result<(), Error> {
         ensure!(self.last_sequence + 1 == sequence, InconsecutiveSequence);
+        self.last_sequence = sequence;
 
-        Ok(Self {
-            last_sequence: sequence,
-            balance: self.balance.checked_sub(amount).context(Underflow)?,
-        })
+        self.balance = self.balance.checked_sub(amount).context(Underflow)?;
+
+        Ok(())
     }
 
     /// Return the last used sequence
@@ -60,28 +59,33 @@ mod tests {
 
     #[test]
     fn debit_too_much_fails() {
-        let account = Account::new();
+        let mut account = Account::new();
 
+        let old_seq = account.last_sequence();
         account
             .debit(1, INITIAL_BALANCE + 1)
             .expect_err("able to debit more than possessed");
+
+        assert!(old_seq < account.last_sequence());
     }
 
     #[test]
     fn debit_increase_sequence() {
-        let account = Account::new();
+        let mut account = Account::new();
 
-        let new_accout = account.debit(1, 1).expect("to debit account");
+        let old_seq = account.last_sequence();
+        account.debit(1, 1).expect("to debit account");
 
-        assert!(account.last_sequence() < new_accout.last_sequence());
+        assert!(old_seq < account.last_sequence());
     }
 
     #[test]
     fn credit_doesnt_change_sequence() {
-        let account = Account::new();
+        let mut account = Account::new();
 
-        let new_accout = account.credit(1).expect("to credit account");
+        let old_seq = account.last_sequence();
+        account.credit(1).expect("to credit account");
 
-        assert_eq!(account.last_sequence(), new_accout.last_sequence());
+        assert_eq!(old_seq, account.last_sequence());
     }
 }

--- a/src/bin/server/main.rs
+++ b/src/bin/server/main.rs
@@ -92,7 +92,7 @@ async fn run() -> Result<(), Error> {
     let config = config::from_reader(io::stdin()).context(Config)?;
 
     let subscriber = FmtSubscriber::builder()
-        .with_max_level(Level::DEBUG)
+        .with_max_level(Level::WARN)
         .finish();
     subscriber::set_global_default(subscriber)
         .context(Logging)


### PR DESCRIPTION
* even an invalid tx should be logged in the accounts (but not changing the balance)
* fix "already existing" in recent txs
* add a timeout in processing the txs, help when users do send invalid tx